### PR TITLE
Fix crash when no auth header is specified

### DIFF
--- a/lib/bot_framework/token_validator.rb
+++ b/lib/bot_framework/token_validator.rb
@@ -46,7 +46,7 @@ module BotFramework
 
     def valid_header?
       # The token was sent in the HTTP Authorization header with "Bearer" scheme
-      condition = auth_header.start_with? 'Bearer'
+      condition = auth_header and auth_header.start_with? 'Bearer'
       errors << 'Invalid headers' unless condition
       condition
     end


### PR DESCRIPTION
```
NoMethodError: undefined method `start_with?' for nil:NilClass
        /usr/lib/ruby/gems/2.4.0/gems/bot_framework-0.1.0beta/lib/bot_framework/token_validator.rb:49:in `valid_header?'
        /usr/lib/ruby/gems/2.4.0/gems/bot_framework-0.1.0beta/lib/bot_framework/token_validator.rb:13:in `valid?'
        /usr/lib/ruby/gems/2.4.0/gems/bot_framework-0.1.0beta/lib/bot_framework/server.rb:40:in `verify'
        /usr/lib/ruby/gems/2.4.0/gems/bot_framework-0.1.0beta/lib/bot_framework/server.rb:11:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/bot_framework-0.1.0beta/lib/bot_framework/server.rb:4:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/tempfile_reaper.rb:15:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/lint.rb:49:in `_call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/lint.rb:37:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/show_exceptions.rb:23:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/common_logger.rb:33:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/chunked.rb:54:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/content_length.rb:15:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/handler/webrick.rb:86:in `service'
        /usr/lib/ruby/2.4.0/webrick/httpserver.rb:140:in `service'
        /usr/lib/ruby/2.4.0/webrick/httpserver.rb:96:in `run'
        /usr/lib/ruby/2.4.0/webrick/server.rb:290:in `block in start_thread'NoMethodError: undefined method `start_with?' for nil:NilClass
        /usr/lib/ruby/gems/2.4.0/gems/bot_framework-0.1.0beta/lib/bot_framework/token_validator.rb:49:in `valid_header?'
        /usr/lib/ruby/gems/2.4.0/gems/bot_framework-0.1.0beta/lib/bot_framework/token_validator.rb:13:in `valid?'
        /usr/lib/ruby/gems/2.4.0/gems/bot_framework-0.1.0beta/lib/bot_framework/server.rb:40:in `verify'
        /usr/lib/ruby/gems/2.4.0/gems/bot_framework-0.1.0beta/lib/bot_framework/server.rb:11:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/bot_framework-0.1.0beta/lib/bot_framework/server.rb:4:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/tempfile_reaper.rb:15:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/lint.rb:49:in `_call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/lint.rb:37:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/show_exceptions.rb:23:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/common_logger.rb:33:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/chunked.rb:54:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/content_length.rb:15:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/handler/webrick.rb:86:in `service'
        /usr/lib/ruby/2.4.0/webrick/httpserver.rb:140:in `service'
        /usr/lib/ruby/2.4.0/webrick/httpserver.rb:96:in `run'
        /usr/lib/ruby/2.4.0/webrick/server.rb:290:in `block in start_thread'
```
