### PR TITLE
Allow Recognizer to not be set

### DIFF
--- a/lib/bot_framework/bot.rb
+++ b/lib/bot_framework/bot.rb
@@ -33,6 +33,7 @@ module BotFramework
         trigger(payload.type.to_sym)
         # Run on default
         trigger(:activity, payload)
+        return unless recognizer
         recognizer.recognize(message: payload.as_json) do |_error, intents|
           trigger_intent_call_back(intents[:intent], payload, intents)
         end


### PR DESCRIPTION
If `BotFramework::Bot.recognizer` isn't set

```
NoMethodError: undefined method `recognize' for nil:NilClass
        /usr/lib/ruby/gems/2.4.0/gems/bot_framework-0.1.0beta/lib/bot_framework/bot.rb:36:in `receive'
        /usr/lib/ruby/gems/2.4.0/gems/bot_framework-0.1.0beta/lib/bot_framework/server.rb:24:in `receive'
        /usr/lib/ruby/gems/2.4.0/gems/bot_framework-0.1.0beta/lib/bot_framework/server.rb:12:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/bot_framework-0.1.0beta/lib/bot_framework/server.rb:4:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/tempfile_reaper.rb:15:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/lint.rb:49:in `_call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/lint.rb:37:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/show_exceptions.rb:23:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/common_logger.rb:33:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/chunked.rb:54:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/content_length.rb:15:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/handler/webrick.rb:86:in `service'
        /usr/lib/ruby/2.4.0/webrick/httpserver.rb:140:in `service'
        /usr/lib/ruby/2.4.0/webrick/httpserver.rb:96:in `run'
        /usr/lib/ruby/2.4.0/webrick/server.rb:290:in `block in start_thread'
```
