### PR TITLE
Fix Regexp Recognizer

### DIFF
--- a/lib/bot_framework/dialogs/reg_exp_recognizer.rb
+++ b/lib/bot_framework/dialogs/reg_exp_recognizer.rb
@@ -20,8 +20,8 @@ module BotFramework
           exp = @expressions[locale] ? @expressions[locale] : @expressions[:*]
           if exp
             matches = exp.match(utterance)
-            if matches && matches.length
-              matched = matches.first
+            if matches && matches.length > 0
+              matched = matches.to_s
               result[:score] = matched.length / utterance.length
               result[:intent] = intent
               result[:expression] = exp


### PR DESCRIPTION
There's no `#first` for `MatchData`

```
NoMethodError: undefined method `first' for #<MatchData "asd" 1:"asd">
        /usr/lib/ruby/gems/2.4.0/gems/bot_framework-0.1.0beta/lib/bot_framework/dialogs/reg_exp_recognizer.rb:24:in `recognize'
        /usr/lib/ruby/gems/2.4.0/gems/bot_framework-0.1.0beta/lib/bot_framework/bot.rb:37:in `receive'
        /usr/lib/ruby/gems/2.4.0/gems/bot_framework-0.1.0beta/lib/bot_framework/server.rb:24:in `receive'
        /usr/lib/ruby/gems/2.4.0/gems/bot_framework-0.1.0beta/lib/bot_framework/server.rb:12:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/bot_framework-0.1.0beta/lib/bot_framework/server.rb:4:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/tempfile_reaper.rb:15:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/lint.rb:49:in `_call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/lint.rb:37:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/show_exceptions.rb:23:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/common_logger.rb:33:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/chunked.rb:54:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/content_length.rb:15:in `call'
        /usr/lib/ruby/gems/2.4.0/gems/rack-2.0.1/lib/rack/handler/webrick.rb:86:in `service'
        /usr/lib/ruby/2.4.0/webrick/httpserver.rb:140:in `service'
        /usr/lib/ruby/2.4.0/webrick/httpserver.rb:96:in `run'
        /usr/lib/ruby/2.4.0/webrick/server.rb:290:in `block in start_thread'
```
