### PR TITLE
Don't try to use callback for nil intent

### DIFF
--- a/lib/bot_framework/bot.rb
+++ b/lib/bot_framework/bot.rb
@@ -35,7 +35,7 @@ module BotFramework
         trigger(:activity, payload)
         return unless recognizer
         recognizer.recognize(message: payload.as_json) do |_error, intents|
-          trigger_intent_call_back(intents[:intent], payload, intents)
+          trigger_intent_call_back(intents[:intent], payload, intents) if intents[:intent]
         end
       end
 


### PR DESCRIPTION
if `intents[:intent]` is `nil` then you'll get
```
"No call back registered for "
```

This removes that message.
