### PR TITLE
Add required fields for Bot Framework Version 3.0

### DIFF
--- a/lib/bot_framework/token_validator.rb
+++ b/lib/bot_framework/token_validator.rb
@@ -62,15 +62,15 @@ module BotFramework
     def valid_iss?
       # The token contains an issuer claim with value of https://api.botframework.com
       iss = JWT.decode(token, nil, false).first['iss']
-      condition = iss == 'https://sts.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/'
+      condition = ['https://sts.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47/', 'https://api.botframework.com'].include?(iss)
       errors << "Invalid iss #{iss}" unless condition
       condition
     end
 
     def valid_audience?
       # The token contains an audience claim with a value equivalent to your bot’s Microsoft App ID.
-      # condition = (JWT.decode(token, nil, false).first['aud'] == BotFramework.connector.app_id)
-      condition = (JWT.decode(token, nil, false).first['aud'] == 'https://graph.microsoft.com')
+      aud = JWT.decode(token, nil, false).first['aud']
+      condition = ['https://graph.microsoft.com', BotFramework.connector.app_id].include?(aud)
       errors << 'Invalid audience' unless condition
       condition
     end


### PR DESCRIPTION
Need these for https://dev.botframework.com/ to work

```
"Errors: [\"Invalid iss https://api.botframework.com\"]"
#<BotFramework::InvalidToken: BotFramework::InvalidToken>
/usr/lib/ruby/2.4.0/gems/botframework-ruby/lib/bot_framework/server.rb:14:in `call'
/usr/lib/ruby/2.4.0/gems/botframework-ruby/lib/bot_framework/server.rb:4:in `call'
```
```
"Errors: [\"Invalid audience\"]"
#<BotFramework::InvalidToken: BotFramework::InvalidToken>
/usr/lib/ruby/2.4.0/gems/botframework-ruby/lib/bot_framework/server.rb:14:in `call'
/usr/lib/ruby/2.4.0/gems/botframework-ruby/lib/bot_framework/server.rb:4:in `call'
```
