### PR TITLE
Use URI and escape

### DIFF
--- a/lib/bot_framework/api_base.rb
+++ b/lib/bot_framework/api_base.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 module BotFramework
   class ApiBase
     include HTTParty
@@ -8,23 +10,23 @@ module BotFramework
     end
 
     def api_get(local_uri, _opts = {})
-      uri = service_url + local_uri
+      uri = URI.join(service_url, URI.escape(local_uri))
       JSON.parse(BotFramework.connector.token.get(uri).body)
     end
 
     def api_post(local_uri, opts = {})
-      uri = service_url + local_uri
+      uri = URI.join(service_url, URI.escape(local_uri))
       JSON.parse(BotFramework.connector.token.post(uri, body: opts.to_json,
                                                         headers: { 'Content-Type' => 'application/json' }).body)
     end
 
     def api_delete(local_uri)
-      uri = service_url + local_uri
+      uri = URI.join(service_url, URI.escape(local_uri))
       BotFramework.connector.token.delete(uri)
     end
 
     def api_request(method, local_uri, opts)
-      uri = service_url + local_uri
+      uri = URI.join(service_url, URI.escape(local_uri))
       BotFramework.connector.token.request(method, uri, opts)
     end
   end


### PR DESCRIPTION
Ruby doesn't consider `|` a valid character in URI so need to escape it

```
#<URI::InvalidURIError: bad URI(is not URI?): https://webchat.botframework.com//v3/conversations/e1925a966c4f425a997b22ae4394ee1b/activities/e1925a966c4f425a997b22ae4394ee1b|0000001>
/usr/lib64/ruby/2.4.0/uri/rfc3986_parser.rb:67:in `split'
/usr/lib64/ruby/2.4.0/uri/rfc3986_parser.rb:73:in `parse'
/usr/lib64/ruby/2.4.0/uri/rfc3986_parser.rb:117:in `convert_to_uri'
/usr/lib64/ruby/2.4.0/uri/generic.rb:1099:in `merge'
/usr/lib/ruby/2.4.0/gems/faraday-0.11.0/lib/faraday/connection.rb:406:in `build_exclusive_url'
/usr/lib/ruby/2.4.0/gems/faraday-0.11.0/lib/faraday/connection.rb:348:in `build_url'
/usr/lib/ruby/2.4.0/gems/oauth2-1.3.1/lib/oauth2/client.rb:97:in `request'
/usr/lib/ruby/2.4.0/gems/oauth2-1.3.1/lib/oauth2/access_token.rb:107:in `request'
/usr/lib/ruby/2.4.0/gems/oauth2-1.3.1/lib/oauth2/access_token.rb:121:in `post'
/usr/lib/ruby/2.4.0/gems/botframework-ruby/lib/bot_framework/api_base.rb:17:in `api_post'
/usr/lib/ruby/2.4.0/gems/botframework-ruby/lib/bot_framework/conversation.rb:30:in `reply_to_activity'
/usr/lib/ruby/2.4.0/gems/botframework-ruby/lib/bot_framework/models/activity.rb:103:in `reply'
lib/io.rb:73:in `flush'
bot.rb:78:in `block in registerCallbacks'
/usr/lib/ruby/2.4.0/gems/botframework-ruby/lib/bot_framework/bot.rb:29:in `instance_exec'
/usr/lib/ruby/2.4.0/gems/botframework-ruby/lib/bot_framework/bot.rb:29:in `trigger_intent_call_back'
/usr/lib/ruby/2.4.0/gems/botframework-ruby/lib/bot_framework/bot.rb:38:in `block in receive'
/usr/lib/ruby/2.4.0/gems/botframework-ruby/lib/bot_framework/dialogs/reg_exp_recognizer.rb:31:in `recognize'
/usr/lib/ruby/2.4.0/gems/botframework-ruby/lib/bot_framework/bot.rb:37:in `receive'
/usr/lib/ruby/2.4.0/gems/botframework-ruby/lib/bot_framework/server.rb:24:in `receive'
/usr/lib/ruby/2.4.0/gems/botframework-ruby/lib/bot_framework/server.rb:12:in `call'
/usr/lib/ruby/2.4.0/gems/botframework-ruby/lib/bot_framework/server.rb:4:in `call'
/usr/lib/ruby/2.4.0/gems/puma-3.8.2/lib/puma/configuration.rb:224:in `call'
/usr/lib/ruby/2.4.0/gems/puma-3.8.2/lib/puma/server.rb:600:in `handle_request'
/usr/lib/ruby/2.4.0/gems/puma-3.8.2/lib/puma/server.rb:435:in `process_client'
/usr/lib/ruby/2.4.0/gems/puma-3.8.2/lib/puma/server.rb:299:in `block in run'
/usr/lib/ruby/2.4.0/gems/puma-3.8.2/lib/puma/thread_pool.rb:120:in `block in spawn_thread'
```
