### PR TITLE
Add another token issuer

### DIFF
--- a/lib/bot_framework/connector.rb
+++ b/lib/bot_framework/connector.rb
@@ -14,6 +14,7 @@ module BotFramework
     EMULATOR_AUDIENCE_METADATA = 'https://login.microsoftonline.com/botframework.com/v2.0/.well-known/openid-configuration'.freeze
     EMULATOR_AUDIENCE = 'https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/'.freeze
     STATE_END_POINT = 'https://state'.freeze
+    ISSUER_DOMAINS = ['sts.windows.net', 'api.botframework.com', 'login.microsoftonline.com'].freeze
 
     def initialize(options = {})
       @app_id = options[:app_id]


### PR DESCRIPTION
When now I tried to connect with Microsoft Bot Framework Channel Emulator

```
E, [2017-11-10T11:10:17.145666 #17949] ERROR -- : Errors: ["Invalid iss https://login.microsoftonline.com/d6d49420-f39b-4df7-a1dc-d59a935871db/v2.0"]
BotFramework::InvalidToken: BotFramework::InvalidToken
        botframework-ruby/lib/bot_framework/server.rb:14:in `call'
        botframework-ruby/lib/bot_framework/server.rb:4:in `call'
```
